### PR TITLE
remove key and update app to use env var

### DIFF
--- a/chop-it-up-frontend/src/index.tsx
+++ b/chop-it-up-frontend/src/index.tsx
@@ -17,17 +17,31 @@ const options = {
   defaults: "2025-05-24",
 };
 
+// Extract shared JSX content to avoid duplication
+const appContent = (
+  <FeatureFlagProvider>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </FeatureFlagProvider>
+);
+
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <PostHogProvider apiKey={POSTHOG_PROJECT_API_KEY} options={options}>
-      <FeatureFlagProvider>
-        <BrowserRouter>
-          <AuthProvider>
-            <App />
-          </AuthProvider>
-        </BrowserRouter>
-      </FeatureFlagProvider>
-    </PostHogProvider>
+    {Boolean(POSTHOG_PROJECT_API_KEY) ? (
+      <PostHogProvider apiKey={POSTHOG_PROJECT_API_KEY} options={options}>
+        {appContent}
+      </PostHogProvider>
+    ) : (
+      (() => {
+        console.info(
+          "PostHog API key not found, skipping PostHogProvider initialization"
+        );
+        return appContent;
+      })()
+    )}
   </React.StrictMode>
 );

--- a/chop-it-up-frontend/src/index.tsx
+++ b/chop-it-up-frontend/src/index.tsx
@@ -6,8 +6,11 @@ import "./index.css";
 import App from "./App";
 import { AuthProvider } from "./context/AuthContext";
 import { PostHogProvider } from "posthog-js/react";
-import { POSTHOG_KEY, POSTHOG_HOST } from "./utils/constants";
+import { POSTHOG_HOST } from "./utils/constants";
 import { FeatureFlagProvider } from "./context/FeatureFlagProvider";
+
+const POSTHOG_PROJECT_API_KEY = import.meta.env
+  .REACT_APP_POSTHOG_PROJECT_API_KEY;
 
 const options = {
   api_host: POSTHOG_HOST,
@@ -17,7 +20,7 @@ const options = {
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <PostHogProvider apiKey={POSTHOG_KEY} options={options}>
+    <PostHogProvider apiKey={POSTHOG_PROJECT_API_KEY} options={options}>
       <FeatureFlagProvider>
         <BrowserRouter>
           <AuthProvider>

--- a/chop-it-up-frontend/src/utils/constants.ts
+++ b/chop-it-up-frontend/src/utils/constants.ts
@@ -1,2 +1,1 @@
-export const POSTHOG_KEY = "phc_8fg9ul7Vw0AorC4qdQLdPNRGiafTmWKtaSZfjtxVKbc";
 export const POSTHOG_HOST = "https://us.i.posthog.com";


### PR DESCRIPTION
remove posthog project api key and replace with new one in environment variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing changes.
- Refactor
  - Conditionally initialize analytics provider at app startup, consolidating shared app mounting logic.
- Chores
  - Move analytics project key sourcing to environment variables and remove the embedded constant.
- Security
  - Removed embedded analytics secret to prevent accidental exposure; behavior falls back gracefully when no key is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->