### PR TITLE
Feat: add per-person payment tracking and receipt soft delete

### DIFF
--- a/backend/migrations/versions/a1b2c3d4e5f6_add_payment_tracking_and_receipt_soft_delete.py
+++ b/backend/migrations/versions/a1b2c3d4e5f6_add_payment_tracking_and_receipt_soft_delete.py
@@ -1,0 +1,34 @@
+"""add payment tracking and receipt soft delete
+
+Revision ID: a1b2c3d4e5f6
+Revises: 8d6982a3f40c
+Create Date: 2026-04-10 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = '8d6982a3f40c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user_receipts', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('deleted_at', sa.TIMESTAMP(timezone=True), nullable=True))
+        batch_op.create_index(batch_op.f('ix_user_receipts_deleted_at'), ['deleted_at'], unique=False)
+
+    with op.batch_alter_table('receipt_users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('paid_at', sa.TIMESTAMP(timezone=True), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('receipt_users', schema=None) as batch_op:
+        batch_op.drop_column('paid_at')
+
+    with op.batch_alter_table('user_receipts', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_user_receipts_deleted_at'))
+        batch_op.drop_column('deleted_at')

--- a/backend/models/receipt_user.py
+++ b/backend/models/receipt_user.py
@@ -14,6 +14,7 @@ class ReceiptUser(db.Model):
         db.TIMESTAMP(timezone=True), server_default=text("CURRENT_TIMESTAMP")
     )
     deleted_at = db.Column(db.TIMESTAMP(timezone=True), nullable=True, index=True)
+    paid_at = db.Column(db.TIMESTAMP(timezone=True), nullable=True)
 
     user = db.relationship("User", backref=db.backref("receipt_users", lazy=True), lazy="joined")
 

--- a/backend/models/user_receipt.py
+++ b/backend/models/user_receipt.py
@@ -20,6 +20,7 @@ class UserReceipt(db.Model):
     created_at = db.Column(
         db.TIMESTAMP(timezone=True), server_default=text("CURRENT_TIMESTAMP")
     )
+    deleted_at = db.Column(db.TIMESTAMP(timezone=True), nullable=True, index=True)
 
     # Denormalized fields extracted from receipt_data (RegularReceipt / TransportationTicket)
     is_receipt = db.Column(db.Boolean, nullable=True, default=True)

--- a/frontend/src/features/bill-split/components/BillBreakdownCollab.tsx
+++ b/frontend/src/features/bill-split/components/BillBreakdownCollab.tsx
@@ -1,25 +1,35 @@
 import { useAuth } from '@clerk/clerk-react';
+import { Trans, useLingui } from '@lingui/react/macro';
+import { useZero } from '@rocicorp/zero/react';
 import { useAtomValue } from 'jotai';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { BillBreakdownView } from '@/features/bill-split/components/BillBreakdownView';
 import {
   assignedUsersAtom,
   personFairTotalsAtom,
+  personPaidStatusAtom,
   personPretaxTotalsAtom,
   receiptAtom,
   receiptTotalAtom,
   useEqualSplitAtom,
 } from '@/features/receipt-collab/atoms/receiptAtoms';
 import { getUserDisplayName } from '@/utils/user-display';
+import { mutators } from '@/zero/mutators';
 
 export const BillBreakdownCollab = () => {
+  const { t } = useLingui();
   const { userId: clerkUserId } = useAuth();
+  const zero = useZero();
+  const navigate = useNavigate();
   const assignedUsers = useAtomValue(assignedUsersAtom);
   const receipt = useAtomValue(receiptAtom);
   const personFairTotals = useAtomValue(personFairTotalsAtom);
   const personPretaxTotals = useAtomValue(personPretaxTotalsAtom);
   const receiptTotal = useAtomValue(receiptTotalAtom);
   const useEqualSplit = useAtomValue(useEqualSplitAtom);
+  const personPaidStatus = useAtomValue(personPaidStatusAtom);
 
   if (!receipt) {
     return null;
@@ -30,7 +40,6 @@ export const BillBreakdownCollab = () => {
     displayName: getUserDisplayName(a),
   }));
 
-  // Resolve which receipt user (if any) is linked to the signed-in Clerk user for the avatar badge.
   let linkedToSignedInUserReceiptUserId: string | null = null;
   if (clerkUserId != null) {
     const claimedBySignedInUser = assignedUsers.find(
@@ -39,6 +48,42 @@ export const BillBreakdownCollab = () => {
     linkedToSignedInUserReceiptUserId =
       claimedBySignedInUser?.receiptUserId ?? null;
   }
+
+  const handleTogglePaid = async (
+    receiptUserId: string,
+    currentlyPaid: boolean
+  ) => {
+    try {
+      const result = zero.mutate(
+        mutators.receiptUsers.updatePaidStatus({
+          id: receiptUserId,
+          paid_at: currentlyPaid ? null : Date.now(),
+        })
+      );
+      const clientResult = await result.client;
+      if (clientResult.type === 'error') {
+        toast.error(t`Failed to update payment status`);
+      }
+    } catch {
+      toast.error(t`Failed to update payment status`);
+    }
+  };
+
+  const handleSoftDelete = async () => {
+    try {
+      const result = zero.mutate(
+        mutators.receipts.softDelete({ id: receipt.id })
+      );
+      const clientResult = await result.client;
+      if (clientResult.type === 'error') {
+        toast.error(t`Failed to delete receipt`);
+        return;
+      }
+      navigate('/', { replace: true });
+    } catch {
+      toast.error(t`Failed to delete receipt`);
+    }
+  };
 
   return (
     <BillBreakdownView
@@ -49,6 +94,9 @@ export const BillBreakdownCollab = () => {
       receiptTotal={receiptTotal}
       useEqualSplit={useEqualSplit}
       linkedToSignedInUserReceiptUserId={linkedToSignedInUserReceiptUserId}
+      personPaidStatus={personPaidStatus}
+      onTogglePaid={handleTogglePaid}
+      onSoftDelete={handleSoftDelete}
     />
   );
 };

--- a/frontend/src/features/bill-split/components/BillBreakdownView.tsx
+++ b/frontend/src/features/bill-split/components/BillBreakdownView.tsx
@@ -1,6 +1,7 @@
 import { Plural, Trans, useLingui } from '@lingui/react/macro';
 import Decimal from 'decimal.js';
-import { Check, FileText, UserPlus } from 'lucide-react';
+import { ArrowRight, Check, Circle, FileText, UserPlus } from 'lucide-react';
+import { useState } from 'react';
 
 import { getAvatarChipColors } from '@/components/Receipt/utils/avatar-chip-colors';
 import { formatCurrency } from '@/components/Receipt/utils/format-currency';
@@ -13,6 +14,7 @@ import {
   DialogClose,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -30,8 +32,10 @@ export interface BillBreakdownViewProps {
   receiptTotal: Decimal;
   useEqualSplit: boolean;
   onManagePeopleClick?: () => void;
-  /** Receipt user id linked to the signed-in user; show badge on that person's avatar when set */
   linkedToSignedInUserReceiptUserId?: string | null;
+  personPaidStatus: Map<string, boolean>;
+  onTogglePaid: (receiptUserId: string, currentlyPaid: boolean) => void;
+  onSoftDelete: () => void;
 }
 
 export const BillBreakdownView = ({
@@ -43,6 +47,9 @@ export const BillBreakdownView = ({
   useEqualSplit,
   onManagePeopleClick,
   linkedToSignedInUserReceiptUserId,
+  personPaidStatus,
+  onTogglePaid,
+  onSoftDelete,
 }: BillBreakdownViewProps) => {
   const { t } = useLingui();
 
@@ -78,6 +85,9 @@ export const BillBreakdownView = ({
   const chipColors = getAvatarChipColors(receipt.id, personIds);
   const idToName = new Map(people.map((p) => [p.id, p.displayName]));
 
+  const allPaid =
+    people.length > 0 && people.every((p) => personPaidStatus.get(p.id));
+
   return (
     <div className="space-y-2">
       <h3 className="mb-1 font-medium">
@@ -86,6 +96,7 @@ export const BillBreakdownView = ({
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {people.map((person) => {
           const c = chipColors.get(person.id);
+          const isPaid = personPaidStatus.get(person.id) ?? false;
 
           const personFairTotal: Decimal =
             personFairTotals.get(person.id) ?? new Decimal(0);
@@ -127,11 +138,13 @@ export const BillBreakdownView = ({
 
           return (
             <Dialog key={person.id}>
-              <DialogTrigger asChild>
-                <button
-                  type="button"
-                  className="font-inherit w-full cursor-pointer rounded-lg border bg-transparent p-4 text-left transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                >
+              <div
+                className={cn(
+                  'overflow-hidden rounded-lg border bg-card transition-shadow',
+                  !isPaid && 'hover:shadow-md'
+                )}
+              >
+                <div className={cn('p-4', isPaid && 'opacity-45')}>
                   <div className="mb-2 flex items-center gap-2">
                     {personAvatar}
                     <span className="truncate font-medium">
@@ -200,26 +213,60 @@ export const BillBreakdownView = ({
                     </div>
                   )}
 
-                  <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
-                    {!useEqualSplit ? (
-                      <>
-                        <FileText className="h-3 w-3" />
-                        <Trans>
-                          {personItems.length}{' '}
-                          <Plural
-                            value={personItems.length}
-                            one="item"
-                            other="items"
-                          />{' '}
-                          assigned
-                        </Trans>
-                      </>
-                    ) : (
-                      <Trans>Equal amount split</Trans>
-                    )}
+                  {/* Footer row: item count + view items link */}
+                  <div className="mt-3 flex items-center justify-between">
+                    <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                      {!useEqualSplit ? (
+                        <>
+                          <FileText className="h-3 w-3" />
+                          <Trans>
+                            {personItems.length}{' '}
+                            <Plural
+                              value={personItems.length}
+                              one="item"
+                              other="items"
+                            />{' '}
+                            assigned
+                          </Trans>
+                        </>
+                      ) : (
+                        <Trans>Equal amount split</Trans>
+                      )}
+                    </div>
+
+                    <DialogTrigger asChild>
+                      <button
+                        type="button"
+                        className="flex items-center gap-1 text-xs font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      >
+                        <Trans>View items</Trans>
+                        <ArrowRight className="h-3 w-3" />
+                      </button>
+                    </DialogTrigger>
                   </div>
+                </div>
+
+                {/* Paid toggle strip */}
+                <button
+                  type="button"
+                  onClick={() => onTogglePaid(person.id, isPaid)}
+                  className={cn(
+                    'flex w-full items-center gap-2 border-t px-4 py-2.5 text-xs font-medium transition-colors',
+                    isPaid
+                      ? 'bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-400'
+                      : 'text-muted-foreground hover:bg-muted/50'
+                  )}
+                >
+                  {isPaid ? (
+                    <div className="flex h-4 w-4 items-center justify-center rounded-full bg-green-600 dark:bg-green-500">
+                      <Check className="h-2.5 w-2.5 text-white" />
+                    </div>
+                  ) : (
+                    <Circle className="h-4 w-4" />
+                  )}
+                  {isPaid ? <Trans>Paid</Trans> : <Trans>Mark as paid</Trans>}
                 </button>
-              </DialogTrigger>
+              </div>
 
               <DialogContent className="flex max-h-[90vh] flex-col overflow-hidden sm:max-w-md">
                 <DialogHeader>
@@ -379,6 +426,93 @@ export const BillBreakdownView = ({
           );
         })}
       </div>
+
+      {/* Settlement controls */}
+      <SettlementControls
+        allPaid={allPaid}
+        onSoftDelete={onSoftDelete}
+        receiptId={receipt.id}
+      />
     </div>
   );
 };
+
+function SettlementControls({
+  allPaid,
+  onSoftDelete,
+  receiptId,
+}: {
+  allPaid: boolean;
+  onSoftDelete: () => void;
+  receiptId: number;
+}) {
+  const [isMarkedComplete, setIsMarkedComplete] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  return (
+    <div className="mt-4 border-t pt-5">
+      <Button
+        className={cn(
+          'w-full transition-colors',
+          isMarkedComplete &&
+            'bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800'
+        )}
+        disabled={!allPaid || isMarkedComplete}
+        onClick={() => setIsMarkedComplete(true)}
+      >
+        {isMarkedComplete ? (
+          <>
+            <Check className="mr-1.5 h-4 w-4" />
+            <Trans>Marked complete</Trans>
+          </>
+        ) : (
+          <Trans>All settled — mark complete</Trans>
+        )}
+      </Button>
+
+      <div
+        className={cn(
+          'mt-3 text-center transition-opacity',
+          isMarkedComplete
+            ? 'opacity-100'
+            : 'pointer-events-none select-none opacity-0'
+        )}
+      >
+        <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <DialogTrigger asChild>
+            <button
+              type="button"
+              className="text-xs font-medium text-destructive/65 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <Trans>Delete this record</Trans>
+            </button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>
+                <Trans>Delete receipt?</Trans>
+              </DialogTitle>
+              <DialogDescription>
+                <Trans>
+                  This will remove the receipt for everyone who has the link.
+                  This action cannot be undone.
+                </Trans>
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setDeleteDialogOpen(false)}
+              >
+                <Trans>Cancel</Trans>
+              </Button>
+              <Button variant="destructive" onClick={onSoftDelete}>
+                <Trans>Delete</Trans>
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/bill-split/components/BillBreakdownView.tsx
+++ b/frontend/src/features/bill-split/components/BillBreakdownView.tsx
@@ -428,10 +428,7 @@ export const BillBreakdownView = ({
       </div>
 
       {/* Settlement controls */}
-      <SettlementControls
-        allPaid={allPaid}
-        onSoftDelete={onSoftDelete}
-      />
+      <SettlementControls allPaid={allPaid} onSoftDelete={onSoftDelete} />
     </div>
   );
 };

--- a/frontend/src/features/bill-split/components/BillBreakdownView.tsx
+++ b/frontend/src/features/bill-split/components/BillBreakdownView.tsx
@@ -443,6 +443,11 @@ function SettlementControls({
   allPaid: boolean;
   onSoftDelete: () => void;
 }) {
+  // Intentionally ephemeral: this is a one-click confirmation step that
+  // reveals the destructive "Delete this record" action. There is no backend
+  // "marked complete" concept — persistence comes from allPaid (each user's
+  // paidAt timestamp). On remount, allPaid will still be true, so the user
+  // simply clicks once again. No data is lost.
   const [isMarkedComplete, setIsMarkedComplete] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 

--- a/frontend/src/features/bill-split/components/BillBreakdownView.tsx
+++ b/frontend/src/features/bill-split/components/BillBreakdownView.tsx
@@ -431,7 +431,6 @@ export const BillBreakdownView = ({
       <SettlementControls
         allPaid={allPaid}
         onSoftDelete={onSoftDelete}
-        receiptId={receipt.id}
       />
     </div>
   );
@@ -440,11 +439,9 @@ export const BillBreakdownView = ({
 function SettlementControls({
   allPaid,
   onSoftDelete,
-  receiptId,
 }: {
   allPaid: boolean;
   onSoftDelete: () => void;
-  receiptId: number;
 }) {
   const [isMarkedComplete, setIsMarkedComplete] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);

--- a/frontend/src/features/bill-split/components/BillBreakdownView.tsx
+++ b/frontend/src/features/bill-split/components/BillBreakdownView.tsx
@@ -467,49 +467,44 @@ function SettlementControls({
         )}
       </Button>
 
-      <div
-        className={cn(
-          'mt-3 text-center transition-opacity',
-          isMarkedComplete
-            ? 'opacity-100'
-            : 'pointer-events-none select-none opacity-0'
-        )}
-      >
-        <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-          <DialogTrigger asChild>
-            <button
-              type="button"
-              className="text-xs font-medium text-destructive/65 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            >
-              <Trans>Delete this record</Trans>
-            </button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                <Trans>Delete receipt?</Trans>
-              </DialogTitle>
-              <DialogDescription>
-                <Trans>
-                  This will remove the receipt for everyone who has the link.
-                  This action cannot be undone.
-                </Trans>
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => setDeleteDialogOpen(false)}
+      {isMarkedComplete && (
+        <div className="mt-3 text-center">
+          <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="text-xs font-medium text-destructive/65 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               >
-                <Trans>Cancel</Trans>
-              </Button>
-              <Button variant="destructive" onClick={onSoftDelete}>
-                <Trans>Delete</Trans>
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </div>
+                <Trans>Delete this record</Trans>
+              </button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>
+                  <Trans>Delete receipt?</Trans>
+                </DialogTitle>
+                <DialogDescription>
+                  <Trans>
+                    This will remove the receipt for everyone who has the link.
+                    This action cannot be undone.
+                  </Trans>
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setDeleteDialogOpen(false)}
+                >
+                  <Trans>Cancel</Trans>
+                </Button>
+                <Button variant="destructive" onClick={onSoftDelete}>
+                  <Trans>Delete</Trans>
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/receipt-collab/atoms/receiptAtoms.ts
+++ b/frontend/src/features/receipt-collab/atoms/receiptAtoms.ts
@@ -239,3 +239,16 @@ export const assignedUsersAtom = atom((get) => {
   }
   return Array.from(userMap.values());
 });
+
+/**
+ * Maps receiptUserId -> boolean indicating whether the person is marked as paid.
+ * Derived from assignedUsers' receiptUser.paidAt field.
+ */
+export const personPaidStatusAtom = atom((get) => {
+  const assignedUsers = get(assignedUsersAtom);
+  const paidMap = new Map<string, boolean>();
+  for (const a of assignedUsers) {
+    paidMap.set(a.receiptUserId, a.receiptUser?.paidAt != null);
+  }
+  return paidMap;
+});

--- a/frontend/src/features/receipt-collab/components/ReceiptCollabContent.tsx
+++ b/frontend/src/features/receipt-collab/components/ReceiptCollabContent.tsx
@@ -123,7 +123,7 @@ export const ReceiptCollabContent = () => {
 
           <BillSplitSectionCollab />
 
-          {isLocalDevelopment() && <ReceiptViewer />}
+          {/* {isLocalDevelopment() && <ReceiptViewer />} */}
         </div>
       </div>
     </motion.div>

--- a/frontend/src/models/Receipt.ts
+++ b/frontend/src/models/Receipt.ts
@@ -110,6 +110,10 @@ export interface Receipt {
   /** Whether tip percentage buttons should calculate based on post-tax amount */
   readonly tipAfterTax: boolean;
 
+  // Soft delete
+  /** The date and time when this receipt was soft-deleted, or null if active */
+  readonly deletedAt: Date | null;
+
   // Line items
   /** Array of line items that make up this receipt */
   readonly lineItems: readonly ReceiptLineItem[];

--- a/frontend/src/models/Receipt.ts
+++ b/frontend/src/models/Receipt.ts
@@ -35,6 +35,7 @@ import type { ReceiptLineItem } from './ReceiptLineItem';
  *   isReceipt: true,
  *   taxIncludedInItems: false,
  *   tipAfterTax: false,
+ *   deletedAt: null,
  *   lineItems: []
  * };
  * ```

--- a/frontend/src/models/ReceiptUser.ts
+++ b/frontend/src/models/ReceiptUser.ts
@@ -16,6 +16,7 @@ import type { User } from './User';
  *   displayName: "Jane Doe",
  *   createdAt: new Date("2024-01-15"),
  *   deletedAt: null,
+ *   paidAt: new Date("2024-01-20"),
  *   user: {
  *     id: 42,
  *     authUserId: "user_2abc123",

--- a/frontend/src/models/ReceiptUser.ts
+++ b/frontend/src/models/ReceiptUser.ts
@@ -42,6 +42,9 @@ export interface ReceiptUser {
   /** The date and time when this receipt user was soft-deleted, or null if active */
   readonly deletedAt: Date | null;
 
+  /** The date and time when this receipt user was marked as paid, or null if unpaid */
+  readonly paidAt: Date | null;
+
   /** The linked User, if available and loaded, or null if not loaded or this is an anonymous receipt user */
   readonly user: User | null;
 }

--- a/frontend/src/models/transformers/fromZero.ts
+++ b/frontend/src/models/transformers/fromZero.ts
@@ -50,6 +50,9 @@ export function fromZeroReceipt(zeroReceipt: ReceiptWithLineItems): Receipt {
                 deletedAt: a.receipt_user.deleted_at
                   ? new Date(a.receipt_user.deleted_at)
                   : null,
+                paidAt: a.receipt_user.paid_at
+                  ? new Date(a.receipt_user.paid_at)
+                  : null,
                 user: a.receipt_user.user
                   ? {
                       id: a.receipt_user.user.id,
@@ -100,6 +103,11 @@ export function fromZeroReceipt(zeroReceipt: ReceiptWithLineItems): Receipt {
     isReceipt: zeroReceipt.is_receipt ?? true,
     taxIncludedInItems: zeroReceipt.tax_included_in_items ?? false,
     tipAfterTax: zeroReceipt.tip_after_tax ?? false,
+
+    // Soft delete
+    deletedAt: zeroReceipt.deleted_at
+      ? new Date(zeroReceipt.deleted_at)
+      : null,
 
     // Line items
     lineItems,

--- a/frontend/src/models/transformers/fromZero.ts
+++ b/frontend/src/models/transformers/fromZero.ts
@@ -50,7 +50,7 @@ export function fromZeroReceipt(zeroReceipt: ReceiptWithLineItems): Receipt {
                 deletedAt: a.receipt_user.deleted_at
                   ? new Date(a.receipt_user.deleted_at)
                   : null,
-                paidAt: a.receipt_user.paid_at
+                paidAt: a.receipt_user.paid_at != null
                   ? new Date(a.receipt_user.paid_at)
                   : null,
                 user: a.receipt_user.user
@@ -105,7 +105,7 @@ export function fromZeroReceipt(zeroReceipt: ReceiptWithLineItems): Receipt {
     tipAfterTax: zeroReceipt.tip_after_tax ?? false,
 
     // Soft delete
-    deletedAt: zeroReceipt.deleted_at
+    deletedAt: zeroReceipt.deleted_at != null
       ? new Date(zeroReceipt.deleted_at)
       : null,
 

--- a/frontend/src/models/transformers/fromZero.ts
+++ b/frontend/src/models/transformers/fromZero.ts
@@ -50,9 +50,10 @@ export function fromZeroReceipt(zeroReceipt: ReceiptWithLineItems): Receipt {
                 deletedAt: a.receipt_user.deleted_at
                   ? new Date(a.receipt_user.deleted_at)
                   : null,
-                paidAt: a.receipt_user.paid_at != null
-                  ? new Date(a.receipt_user.paid_at)
-                  : null,
+                paidAt:
+                  a.receipt_user.paid_at != null
+                    ? new Date(a.receipt_user.paid_at)
+                    : null,
                 user: a.receipt_user.user
                   ? {
                       id: a.receipt_user.user.id,
@@ -105,9 +106,8 @@ export function fromZeroReceipt(zeroReceipt: ReceiptWithLineItems): Receipt {
     tipAfterTax: zeroReceipt.tip_after_tax ?? false,
 
     // Soft delete
-    deletedAt: zeroReceipt.deleted_at != null
-      ? new Date(zeroReceipt.deleted_at)
-      : null,
+    deletedAt:
+      zeroReceipt.deleted_at != null ? new Date(zeroReceipt.deleted_at) : null,
 
     // Line items
     lineItems,

--- a/frontend/src/zero/mutators.ts
+++ b/frontend/src/zero/mutators.ts
@@ -15,6 +15,15 @@ export const mutators = defineMutators({
         await tx.mutate.user_receipts.update(args);
       }
     ),
+    softDelete: defineMutator(
+      z.object({ id: z.number() }),
+      async ({ tx, args }) => {
+        await tx.mutate.user_receipts.update({
+          id: args.id,
+          deleted_at: Date.now(),
+        });
+      }
+    ),
   },
   lineItems: {
     update: defineMutator(
@@ -83,6 +92,18 @@ export const mutators = defineMutators({
       }),
       async ({ tx, args }) => {
         await tx.mutate.receipt_users.update(args);
+      }
+    ),
+    updatePaidStatus: defineMutator(
+      z.object({
+        id: z.string(),
+        paid_at: z.number().nullable(),
+      }),
+      async ({ tx, args }) => {
+        await tx.mutate.receipt_users.update({
+          id: args.id,
+          paid_at: args.paid_at,
+        });
       }
     ),
     delete: defineMutator(

--- a/frontend/src/zero/queries.ts
+++ b/frontend/src/zero/queries.ts
@@ -9,7 +9,9 @@ export const queries = defineQueries({
       byAuthUserId: defineQuery(z.object({}), ({ ctx }) =>
         zql.users
           .where('auth_user_id', ctx.userID ?? '')
-          .related('receipts', (q) => q.orderBy('created_at', 'desc'))
+          .related('receipts', (q) =>
+            q.where('deleted_at', 'IS', null).orderBy('created_at', 'desc')
+          )
           .one()
       ),
     },
@@ -18,6 +20,7 @@ export const queries = defineQueries({
     byId: defineQuery(z.object({ id: z.number() }), ({ args: { id } }) =>
       zql.user_receipts
         .where('id', id)
+        .where('deleted_at', 'IS', null)
         .related('line_items', (q) =>
           q
             .where('deleted_at', 'IS', null)

--- a/frontend/src/zero/schemas/receipt-user.ts
+++ b/frontend/src/zero/schemas/receipt-user.ts
@@ -23,5 +23,6 @@ export const receiptUser = table('receipt_users')
     display_name: string().optional(),
     created_at: number(),
     deleted_at: number().optional(),
+    paid_at: number().optional(),
   })
   .primaryKey('id');

--- a/frontend/src/zero/schemas/user-receipt.ts
+++ b/frontend/src/zero/schemas/user-receipt.ts
@@ -51,5 +51,6 @@ export const userReceipt = table('user_receipts')
     currency: string().optional(),
     taxes: number().optional(),
     receipt_metadata: json().optional(),
+    deleted_at: number().optional(),
   })
   .primaryKey('id');

--- a/zero-query/src/mutators.ts
+++ b/zero-query/src/mutators.ts
@@ -17,6 +17,15 @@ export const mutators = defineMutators({
         await tx.mutate.user_receipts.update(args);
       }
     ),
+    softDelete: defineMutator(
+      z.object({ id: z.number() }),
+      async ({ tx, args }) => {
+        await tx.mutate.user_receipts.update({
+          id: args.id,
+          deleted_at: Date.now(),
+        });
+      }
+    ),
   },
   lineItems: {
     update: defineMutator(
@@ -152,6 +161,18 @@ export const mutators = defineMutators({
           // Client-side optimistic update -- trust the args
           await tx.mutate.receipt_users.update(args);
         }
+      }
+    ),
+    updatePaidStatus: defineMutator(
+      z.object({
+        id: z.string(),
+        paid_at: z.number().nullable(),
+      }),
+      async ({ tx, args }) => {
+        await tx.mutate.receipt_users.update({
+          id: args.id,
+          paid_at: args.paid_at,
+        });
       }
     ),
     delete: defineMutator(

--- a/zero-query/src/queries.ts
+++ b/zero-query/src/queries.ts
@@ -9,7 +9,9 @@ export const queries = defineQueries({
       byAuthUserId: defineQuery(z.object({}), ({ ctx }) =>
         zql.users
           .where('auth_user_id', ctx.userID ?? '')
-          .related('receipts', (q) => q.orderBy('created_at', 'desc'))
+          .related('receipts', (q) =>
+            q.where('deleted_at', 'IS', null).orderBy('created_at', 'desc')
+          )
           .one()
       ),
     },
@@ -18,6 +20,7 @@ export const queries = defineQueries({
     byId: defineQuery(z.object({ id: z.number() }), ({ args: { id } }) =>
       zql.user_receipts
         .where('id', id)
+        .where('deleted_at', 'IS', null)
         .related('line_items', (q) =>
           q
             .where('deleted_at', 'IS', null)

--- a/zero-query/src/schemas/receipt-user.ts
+++ b/zero-query/src/schemas/receipt-user.ts
@@ -23,5 +23,6 @@ export const receiptUser = table('receipt_users')
     display_name: string().optional(),
     created_at: number(),
     deleted_at: number().optional(),
+    paid_at: number().optional(),
   })
   .primaryKey('id');

--- a/zero-query/src/schemas/user-receipt.ts
+++ b/zero-query/src/schemas/user-receipt.ts
@@ -50,5 +50,6 @@ export const userReceipt = table('user_receipts')
     currency: string().optional(),
     taxes: number().optional(),
     receipt_metadata: json().optional(),
+    deleted_at: number().optional(),
   })
   .primaryKey('id');


### PR DESCRIPTION
Persist paid/unpaid state per receipt participant via a new `paid_at` column on `receipt_users`, synced through Zero. Add receipt-level soft delete via `deleted_at` on `user_receipts` so deleted receipt links naturally resolve to 404 through the existing query/retry flow.

- Extend SQLAlchemy models, Alembic migration, and both Zero schema copies
- Filter deleted receipts in `receipt.byId` and owner receipt-list queries
- Add `receipts.softDelete` and `receiptUsers.updatePaidStatus` mutators
- Thread `paidAt`/`deletedAt` through fromZero transformer, app types, and a new `personPaidStatusAtom` derived atom
- Refactor BillBreakdownView cards to separate the dialog trigger from a new paid toggle strip, add "View items" footer link, settlement controls with "All settled — mark complete" button, and a delete confirmation dialog

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track and display per-person payment status on shared bills.
  * Toggle a participant as paid/unpaid directly from the bill view.
  * "All settled — mark complete" flow when everyone is paid.
  * Archive (soft-delete) receipts; archived receipts are hidden from lists.
  * Option to permanently remove a receipt after marking complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->