### PR TITLE
Feat: add receipt totals reconciliation and retry logic to image anal…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,6 +45,10 @@ GOOGLE_API_KEY=your_google_api_key_here
 # Flask secret key (generate with: python -c "import secrets; print(secrets.token_hex(32))")
 SECRET_KEY=your_flask_secret_key_here
 
+# When true, a receipt subtotal mismatch triggers one targeted Gemini retry
+# with arithmetic hints. Set to false/0/no to disable retries without a deploy.
+RECEIPT_RETRY_ON_MISMATCH=true
+
 # Server port
 PORT=5001
 

--- a/backend/image_analyzer.py
+++ b/backend/image_analyzer.py
@@ -2,7 +2,10 @@ import json
 import logging
 import os
 import re
+from dataclasses import dataclass, field
+from decimal import Decimal
 from pathlib import Path
+from typing import Optional
 
 import google.generativeai as genai
 from dotenv import load_dotenv
@@ -20,6 +23,35 @@ from schemas.receipt import (
 logger = logging.getLogger(__name__)
 
 _is_dev = os.environ.get("VERCEL_ENV", "production") != "production"
+
+# ---------------------------------------------------------------------------
+# Reconciliation configuration
+# ---------------------------------------------------------------------------
+# Tolerance for sum(line_item.total_price) vs. printed subtotal. $0.05 absorbs
+# per-line rounding on receipts that independently round unit×qty.
+RECONCILIATION_TOLERANCE = Decimal("0.05")
+
+# When True, a mismatch triggers one targeted Gemini retry with arithmetic
+# hints. Disable during incident response without a code deploy.
+RECEIPT_RETRY_ON_MISMATCH: bool = True
+
+
+@dataclass
+class _SuspectItem:
+    """A line item that is likely the source of a reconciliation mismatch."""
+    name: str
+    qty: float
+    unit_price: Decimal
+    total_price: Decimal
+
+
+@dataclass
+class _ReconciliationResult:
+    ok: bool
+    items_sum: Decimal = Decimal("0")
+    printed_subtotal: Decimal = Decimal("0")
+    delta: Decimal = Decimal("0")
+    suspect: Optional[_SuspectItem] = None
 
 
 class ImageAnalysisError(Exception):
@@ -104,7 +136,7 @@ class ImageAnalyzer:
             ) from e
 
     def _analyze_image_with_gemini(self, image_data_or_path, mime_type="image/jpeg"):
-        """Analyze image using Google Gemini"""
+        """Analyze image using Google Gemini, with one targeted retry on totals mismatch."""
         # Handle both binary data and file path
         if isinstance(image_data_or_path, bytes):
             image_data = image_data_or_path
@@ -118,14 +150,12 @@ class ImageAnalyzer:
         # Create the model
         model = genai.GenerativeModel("models/gemini-2.5-flash-lite")
 
-        # Create the content parts
+        # --- First pass ---
         content_parts = [
             self._get_system_prompt(),
             "Analyze this image and extract all relevant payment information. This might be a receipt, invoice, or transportation ticket. Pay special attention to any monetary amounts shown.",
             {"mime_type": mime_type, "data": image_data},
         ]
-
-        # Generate content
         response = model.generate_content(content_parts)
 
         logger.debug("[analyzer] Gemini response length: %d", len(response.text))
@@ -135,7 +165,160 @@ class ImageAnalyzer:
                 response.text[:2000],
             )
 
-        return self._process_response(response.text)
+        receipt_model = self._process_response(response.text)
+
+        # --- Reconciliation check + optional retry ---
+        if RECEIPT_RETRY_ON_MISMATCH and hasattr(receipt_model, "line_items"):
+            reconciliation = self._validate_totals(receipt_model)
+            if not reconciliation.ok:
+                retry_hint = self._build_retry_hint(reconciliation)
+                logger.warning(
+                    "[analyzer] Totals mismatch (delta=%s); retrying with hint. merchant=%s",
+                    reconciliation.delta,
+                    getattr(receipt_model, "merchant", None),
+                )
+                retry_parts = [
+                    self._get_system_prompt(),
+                    "Analyze this image and extract all relevant payment information. This might be a receipt, invoice, or transportation ticket. Pay special attention to any monetary amounts shown.",
+                    {"mime_type": mime_type, "data": image_data},
+                    retry_hint,
+                ]
+                retry_response = model.generate_content(retry_parts)
+                logger.debug(
+                    "[analyzer] Retry Gemini response length: %d",
+                    len(retry_response.text),
+                )
+                try:
+                    retry_model = self._process_response(retry_response.text)
+                    if hasattr(retry_model, "line_items"):
+                        retry_reconciliation = self._validate_totals(retry_model)
+                        if retry_reconciliation.ok:
+                            logger.info(
+                                "[analyzer] Reconciled on retry. merchant=%s",
+                                getattr(retry_model, "merchant", None),
+                            )
+                            return retry_model
+                        else:
+                            logger.error(
+                                "[analyzer] Unreconciled after retry (delta=%s); "
+                                "falling back to first response. merchant=%s",
+                                retry_reconciliation.delta,
+                                getattr(retry_model, "merchant", None),
+                            )
+                    else:
+                        return retry_model
+                except Exception as retry_err:
+                    logger.error(
+                        "[analyzer] Retry response processing failed: %s; "
+                        "falling back to first response.",
+                        retry_err,
+                    )
+            elif _is_dev:
+                logger.debug(
+                    "[analyzer] Totals reconciled (items_sum=%s, subtotal=%s). merchant=%s",
+                    reconciliation.items_sum,
+                    reconciliation.printed_subtotal,
+                    getattr(receipt_model, "merchant", None),
+                )
+
+        return receipt_model
+
+    def _validate_totals(self, receipt_model) -> "_ReconciliationResult":
+        """
+        Compare sum(line_item.total_price) against the printed subtotal.
+
+        Returns a _ReconciliationResult. ok=True when the delta is within
+        RECONCILIATION_TOLERANCE. Also tries to identify the most likely
+        suspect line item responsible for the mismatch.
+        """
+        line_items = getattr(receipt_model, "line_items", [])
+        items_sum = sum(
+            (Decimal(str(item.total_price)) for item in line_items), Decimal("0")
+        ).quantize(Decimal("0.01"))
+
+        # Use the printed subtotal as the oracle. Fall back to total if absent.
+        printed_subtotal = Decimal(
+            str(getattr(receipt_model, "subtotal", None) or getattr(receipt_model, "total", 0) or 0)
+        ).quantize(Decimal("0.01"))
+
+        delta = (items_sum - printed_subtotal).copy_abs()
+
+        if delta <= RECONCILIATION_TOLERANCE:
+            return _ReconciliationResult(
+                ok=True, items_sum=items_sum, printed_subtotal=printed_subtotal, delta=delta
+            )
+
+        if _is_dev:
+            for item in line_items:
+                logger.debug(
+                    "[analyzer] line item: name=%r qty=%s unit=%s total=%s",
+                    item.name,
+                    item.quantity,
+                    item.price_per_item,
+                    item.total_price,
+                )
+
+        # Try to identify the suspect item: the one whose (qty-1)*unit_price
+        # equals the delta (i.e. we counted one extra unit), or whose
+        # unit_price equals delta (we doubled the value by using unit as total).
+        suspect: Optional[_SuspectItem] = None
+        for item in line_items:
+            qty = item.quantity
+            unit = Decimal(str(item.price_per_item)).quantize(Decimal("0.01"))
+            total = Decimal(str(item.total_price)).quantize(Decimal("0.01"))
+            # Classic misread: unit price was used as total, so total = qty * unit
+            # instead of the printed value. Extra amount = (qty - 1) * unit.
+            if qty > 1 and (Decimal(str(qty - 1)) * unit - delta).copy_abs() <= Decimal("0.02"):
+                suspect = _SuspectItem(name=item.name, qty=qty, unit_price=unit, total_price=total)
+                break
+            # Alternate: the printed single number is the total, not the unit price.
+            if qty > 1 and (unit * Decimal(str(qty)) - total - delta).copy_abs() <= Decimal("0.02"):
+                suspect = _SuspectItem(name=item.name, qty=qty, unit_price=unit, total_price=total)
+                break
+
+        return _ReconciliationResult(
+            ok=False,
+            items_sum=items_sum,
+            printed_subtotal=printed_subtotal,
+            delta=items_sum - printed_subtotal,
+            suspect=suspect,
+        )
+
+    def _build_retry_hint(self, result: "_ReconciliationResult") -> str:
+        """
+        Build a targeted correction message to include in the retry prompt.
+        """
+        lines = [
+            f"CORRECTION REQUIRED: Your previous extraction had "
+            f"sum(line_item.total_price) = ${result.items_sum} but the printed "
+            f"subtotal on the receipt is ${result.printed_subtotal} "
+            f"(difference: ${result.delta.copy_abs()}).",
+            "",
+            "The most likely cause is misreading a printed extended-line total as a "
+            "unit price. Remember: when only one price appears next to a quantity > 1, "
+            "that price is almost always the EXTENDED TOTAL (quantity × unit price), "
+            "not the unit price.",
+        ]
+        if result.suspect:
+            s = result.suspect
+            # The extracted unit_price is the value that appeared on the receipt.
+            # In the classic misread, that printed value IS the extended total,
+            # so the correct unit_price = printed_value / qty.
+            corrected_unit = (s.unit_price / Decimal(str(s.qty))).quantize(Decimal("0.01"))
+            lines += [
+                "",
+                f"Suspect line item: '{s.name}' (qty {s.qty}, extracted unit ${s.unit_price}, "
+                f"extracted total ${s.total_price}).",
+                f"The printed value ${s.unit_price} is likely the EXTENDED TOTAL, not the unit "
+                f"price. Correct extraction: total_price={s.unit_price}, "
+                f"price_per_item={corrected_unit}.",
+            ]
+        lines += [
+            "",
+            "Re-extract the receipt. Ensure sum(line_item.total_price) reconciles with "
+            "the printed subtotal before returning your JSON.",
+        ]
+        return "\n".join(lines)
 
     def _with_structured_output(self, analysis_text: str):
         """
@@ -302,7 +485,7 @@ class ImageAnalyzer:
         """Get the system prompt for receipt analysis"""
         return """
         You are a financial document analyzer, specializing in receipts, bills, invoices, transportation tickets, and similar payment documents. First, determine if the image contains any payment document (receipt, bill, invoice, ticket, order confirmation, etc.) with pricing information.
-        
+
         If the image is a TRANSPORTATION TICKET (train, bus, flight, etc.):
         Extract this information in JSON format:
         {
@@ -320,22 +503,18 @@ class ImageAnalyzer:
           "taxes": 0.0,  # Any taxes listed separately
           "total": 20.0  # Total amount paid
         }
-        
+
         If the image is NOT any payment document (contains no prices or payment information), respond with: {"is_receipt": false, "reason": "Brief explanation of what the image appears to contain and why it is not a receipt or payment document"}
-        
+
         If it IS a REGULAR payment document (receipt, bill, invoice, order, etc.), extract the following information in JSON format:
         1. Store or merchant name
         2. Date of purchase/invoice/order
-        3. List of items with:
-           - Item name
-           - Quantity (if available)
-           - Price per item (0 if not present)
-           - Total price for the item
-        4. Subtotal (before tax)
+        3. List of items — see LINE ITEM RULES below
+        4. Subtotal (before tax) — copy exactly from the printed document
         5. Tax amount
         6. Tip amount (if present)
         7. Gratuity or service charge (if present, as a separate field from tip)
-        8. Total amount
+        8. Total amount — copy exactly from the printed document
         9. Payment method (if available)
         10. Special fields for different tax handling:
            - tax_included_in_items: (true/false) - Whether tax is already included in item prices
@@ -344,6 +523,42 @@ class ImageAnalyzer:
            - pretax_total: Total before tax (might be different from items_total if there are discounts)
            - posttax_total: Total after tax is applied (but before tip/gratuity)
            - final_total: The final total including everything (tax, tip, gratuity)
+
+        SOURCE OF TRUTH — READ THIS CAREFULLY:
+        The printed subtotal, tax, tip/gratuity, and total on the receipt are the source of truth.
+        Before you return your JSON, mentally verify: sum(line_item.total_price) must equal the
+        printed subtotal (within $0.05 for rounding). If it does not, you have a mis-extracted
+        line item — re-read each line and fix it before returning.
+
+        LINE ITEM RULES:
+        For each line item extract:
+        - "name": item description
+        - "quantity": number of units (default 1 if not printed)
+        - "total_price": the EXTENDED total for this line — what this line contributes to the
+          subtotal. This is the key figure. Read it directly from the receipt.
+        - "price_per_item": the per-unit price. If only one price is printed next to a
+          multi-quantity line, that price is almost always the EXTENDED TOTAL, not the unit price.
+
+        IMPORTANT — UNIT PRICE vs. EXTENDED TOTAL:
+        Many receipts show only one price column. That column is the extended total (qty × unit).
+        Example of the WRONG interpretation:
+          Receipt line: "2 Soda   $12"
+          Wrong: quantity=2, price_per_item=12.00, total_price=24.00  ← sum would be $12 too high
+        Example of the CORRECT interpretation:
+          Receipt line: "2 Soda   $12"
+          Correct: quantity=2, price_per_item=6.00, total_price=12.00  ← printed $12 is the total
+        Rule: if treating the printed price as the unit price causes sum(total_price) to exceed
+        the printed subtotal, treat the printed price as the extended total instead, and derive
+        price_per_item = printed_price / quantity.
+
+        SELF-CHECK (mandatory before returning JSON):
+        1. Add up all line_item.total_price values.
+        2. Compare the sum to the printed subtotal on the receipt.
+        3. If the difference is more than $0.05, re-inspect your line items for the
+           unit-vs-extended misread above and fix them.
+        4. If you truly cannot reconcile (illegible receipt, complex discounts), keep your
+           best-effort values but ensure total_price values do not silently inflate the sum
+           beyond the printed subtotal.
 
         Format your response as valid JSON like this:
         {
@@ -355,7 +570,7 @@ class ImageAnalyzer:
               "name": "Item 1",
               "quantity": 2,
               "price_per_item": 10.99,
-              "total_price": 21.98,
+              "total_price": 21.98
             },
             ...
           ],
@@ -372,14 +587,14 @@ class ImageAnalyzer:
           "posttax_total": 49.65,
           "final_total": 62.15
         }
-        
+
         For tips and gratuity:
         - Report "tip" for any discretionary amounts added by the customer
         - Report "gratuity" for any mandatory service charges added by the establishment
         - Pre-calculated tip options with one selected should be under "tip"
         - If no tip is found, set tip to 0.0
         - If no gratuity is found, you can omit that field or set it to 0.0
-        
+
         For tax handling and totals:
         - Set "tax_included_in_items" to true if the document indicates tax is already included in item prices
         - "display_subtotal" should be the subtotal exactly as shown on the document
@@ -388,10 +603,10 @@ class ImageAnalyzer:
         - "posttax_total" is the amount after tax but before tip/gratuity
         - "final_total" is the very final amount including everything
         - "total" should be the final total (same as final_total) for backward compatibility
-        
+
         If you can't determine some of these special fields, make your best estimation based on the values you can see.
         The most important thing is to correctly identify if tax is included in items or added separately.
-        
+
         Use null for any other fields that cannot be determined and are not supposed to be numbers. Ensure all numbers are formatted as numbers, not strings.
         Use 0 for amounts that are not present or cannot be determined.
         Note: Use 'line_items' (not 'items') as the key for the list of purchased items.

--- a/backend/image_analyzer.py
+++ b/backend/image_analyzer.py
@@ -33,7 +33,7 @@ RECONCILIATION_TOLERANCE = Decimal("0.05")
 
 # When True, a mismatch triggers one targeted Gemini retry with arithmetic
 # hints. Disable during incident response without a code deploy.
-RECEIPT_RETRY_ON_MISMATCH: bool = True
+RECEIPT_RETRY_ON_MISMATCH: bool = os.getenv("RECEIPT_RETRY_ON_MISMATCH", "true").strip().lower() in ("1", "true", "yes")
 
 
 @dataclass

--- a/backend/image_analyzer.py
+++ b/backend/image_analyzer.py
@@ -206,6 +206,17 @@ class ImageAnalyzer:
                                 getattr(retry_model, "merchant", None),
                             )
                     else:
+                        logger.warning(
+                            "[analyzer] Retry returned unexpected type %s "
+                            "(original type=%s); returning retry model as-is. "
+                            "merchant=%s image=%s",
+                            retry_model.__class__.__name__,
+                            receipt_model.__class__.__name__,
+                            getattr(retry_model, "merchant", None),
+                            image_data_or_path
+                            if isinstance(image_data_or_path, str)
+                            else "<bytes>",
+                        )
                         return retry_model
                 except Exception as retry_err:
                     logger.error(

--- a/backend/image_analyzer.py
+++ b/backend/image_analyzer.py
@@ -291,7 +291,7 @@ class ImageAnalyzer:
             ok=False,
             items_sum=items_sum,
             printed_subtotal=printed_subtotal,
-            delta=items_sum - printed_subtotal,
+            delta=delta,  # already absolute from copy_abs() above
             suspect=suspect,
         )
 

--- a/backend/image_analyzer.py
+++ b/backend/image_analyzer.py
@@ -31,10 +31,6 @@ _is_dev = os.environ.get("VERCEL_ENV", "production") != "production"
 # per-line rounding on receipts that independently round unit×qty.
 RECONCILIATION_TOLERANCE = Decimal("0.05")
 
-# When True, a mismatch triggers one targeted Gemini retry with arithmetic
-# hints. Disable during incident response without a code deploy.
-RECEIPT_RETRY_ON_MISMATCH: bool = os.getenv("RECEIPT_RETRY_ON_MISMATCH", "true").strip().lower() in ("1", "true", "yes")
-
 
 @dataclass
 class _SuspectItem:
@@ -70,6 +66,10 @@ class ImageAnalyzerConfigError(Exception):
 backend_dir = Path(__file__).resolve().parent
 env_path = backend_dir / ".env"
 load_dotenv(env_path)
+
+# When True, a mismatch triggers one targeted Gemini retry with arithmetic
+# hints. Disable during incident response without a code deploy.
+RECEIPT_RETRY_ON_MISMATCH: bool = os.getenv("RECEIPT_RETRY_ON_MISMATCH", "true").strip().lower() in ("1", "true", "yes")
 
 # Module-level flag to track if configuration has been done
 _configured = False

--- a/backend/image_analyzer.py
+++ b/backend/image_analyzer.py
@@ -248,8 +248,10 @@ class ImageAnalyzer:
         ).quantize(Decimal("0.01"))
 
         # Use the printed subtotal as the oracle. Fall back to total if absent.
+        _subtotal = getattr(receipt_model, "subtotal", None)
+        _total = getattr(receipt_model, "total", None)
         printed_subtotal = Decimal(
-            str(getattr(receipt_model, "subtotal", None) or getattr(receipt_model, "total", 0) or 0)
+            str(_subtotal if _subtotal is not None else (_total if _total is not None else 0))
         ).quantize(Decimal("0.01"))
 
         delta = (items_sum - printed_subtotal).copy_abs()

--- a/backend/image_analyzer.py
+++ b/backend/image_analyzer.py
@@ -282,8 +282,8 @@ class ImageAnalyzer:
             if qty > 1 and (Decimal(str(qty - 1)) * unit - delta).copy_abs() <= Decimal("0.02"):
                 suspect = _SuspectItem(name=item.name, qty=qty, unit_price=unit, total_price=total)
                 break
-            # Alternate: the printed single number is the total, not the unit price.
-            if qty > 1 and (unit * Decimal(str(qty)) - total - delta).copy_abs() <= Decimal("0.02"):
+            # Alternate: the item is wholly spurious — qty × unit equals the full delta.
+            if qty > 1 and (Decimal(str(qty)) * unit - delta).copy_abs() <= Decimal("0.02"):
                 suspect = _SuspectItem(name=item.name, qty=qty, unit_price=unit, total_price=total)
                 break
 

--- a/backend/image_analyzer.py
+++ b/backend/image_analyzer.py
@@ -177,18 +177,18 @@ class ImageAnalyzer:
                     reconciliation.delta,
                     getattr(receipt_model, "merchant", None),
                 )
-                retry_parts = [
-                    self._get_system_prompt(),
-                    "Analyze this image and extract all relevant payment information. This might be a receipt, invoice, or transportation ticket. Pay special attention to any monetary amounts shown.",
-                    {"mime_type": mime_type, "data": image_data},
-                    retry_hint,
-                ]
-                retry_response = model.generate_content(retry_parts)
-                logger.debug(
-                    "[analyzer] Retry Gemini response length: %d",
-                    len(retry_response.text),
-                )
                 try:
+                    retry_parts = [
+                        self._get_system_prompt(),
+                        "Analyze this image and extract all relevant payment information. This might be a receipt, invoice, or transportation ticket. Pay special attention to any monetary amounts shown.",
+                        {"mime_type": mime_type, "data": image_data},
+                        retry_hint,
+                    ]
+                    retry_response = model.generate_content(retry_parts)
+                    logger.debug(
+                        "[analyzer] Retry Gemini response length: %d",
+                        len(retry_response.text),
+                    )
                     retry_model = self._process_response(retry_response.text)
                     if hasattr(retry_model, "line_items"):
                         retry_reconciliation = self._validate_totals(retry_model)

--- a/backend/tests/test_image_analyzer_reconciliation.py
+++ b/backend/tests/test_image_analyzer_reconciliation.py
@@ -1,0 +1,252 @@
+"""
+Tests for the receipt totals reconciliation logic in image_analyzer.py.
+
+These tests mock `genai.GenerativeModel.generate_content` directly so that
+the full stack — _analyze_image_with_gemini → _process_response →
+_with_structured_output → _validate_totals — is exercised.
+"""
+
+import json
+import logging
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+import image_analyzer as ia
+from image_analyzer import (
+    RECONCILIATION_TOLERANCE,
+    ImageAnalyzer,
+    _ReconciliationResult,
+    _SuspectItem,
+)
+from schemas.receipt import RegularReceipt
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _gemini_response(payload: dict) -> SimpleNamespace:
+    """Wrap a dict in a fake Gemini response object."""
+    return SimpleNamespace(text=json.dumps(payload))
+
+
+def _good_receipt() -> dict:
+    """A receipt where sum(total_price) == subtotal."""
+    return {
+        "is_receipt": True,
+        "merchant": "Good Cafe",
+        "date": "2025-01-01",
+        "line_items": [
+            {"name": "Sandwich", "quantity": 1, "price_per_item": 10.00, "total_price": 10.00},
+            {"name": "Soda", "quantity": 2, "price_per_item": 6.00, "total_price": 12.00},
+        ],
+        "subtotal": 22.00,
+        "tax": 2.00,
+        "tip": 0.00,
+        "total": 24.00,
+        "tax_included_in_items": False,
+        "display_subtotal": 22.00,
+        "items_total": 22.00,
+        "pretax_total": 22.00,
+        "posttax_total": 24.00,
+        "final_total": 24.00,
+    }
+
+
+def _bad_receipt() -> dict:
+    """
+    A receipt with the classic unit-vs-extended misread:
+    'Soda' qty 2 at unit $12 (should be $6), giving total_price=24 instead of 12.
+    sum(total_price) = 34 but printed subtotal = 22.
+    """
+    return {
+        "is_receipt": True,
+        "merchant": "Bad Cafe",
+        "date": "2025-01-01",
+        "line_items": [
+            {"name": "Sandwich", "quantity": 1, "price_per_item": 10.00, "total_price": 10.00},
+            {"name": "Soda", "quantity": 2, "price_per_item": 12.00, "total_price": 24.00},
+        ],
+        "subtotal": 22.00,
+        "tax": 2.00,
+        "tip": 0.00,
+        "total": 24.00,
+        "tax_included_in_items": False,
+        "display_subtotal": 22.00,
+        "items_total": 22.00,
+        "pretax_total": 22.00,
+        "posttax_total": 24.00,
+        "final_total": 24.00,
+    }
+
+
+def _corrected_receipt() -> dict:
+    """What Gemini returns on a successful retry."""
+    return _good_receipt() | {"merchant": "Bad Cafe"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _patch_configure():
+    """Skip the real Google API key check."""
+    with patch("image_analyzer._configured", True):
+        yield
+
+
+@pytest.fixture()
+def analyzer():
+    return ImageAnalyzer()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestValidateTotals:
+    """Unit tests for _validate_totals directly."""
+
+    def test_ok_when_sum_matches(self, analyzer):
+        model = RegularReceipt.model_validate(_good_receipt())
+        result = analyzer._validate_totals(model)
+        assert result.ok is True
+        assert result.delta == Decimal("0")
+
+    def test_not_ok_when_sum_differs_by_more_than_tolerance(self, analyzer):
+        model = RegularReceipt.model_validate(_bad_receipt())
+        result = analyzer._validate_totals(model)
+        assert result.ok is False
+        # items_sum = 10 + 24 = 34; subtotal = 22 → delta = 12
+        assert result.delta == Decimal("12.00")
+
+    def test_ok_within_tolerance(self, analyzer):
+        """A penny rounding difference should pass."""
+        receipt = _good_receipt()
+        receipt["subtotal"] = 22.03
+        receipt["display_subtotal"] = 22.03
+        model = RegularReceipt.model_validate(receipt)
+        result = analyzer._validate_totals(model)
+        assert result.ok is True
+
+    def test_suspect_identified(self, analyzer):
+        model = RegularReceipt.model_validate(_bad_receipt())
+        result = analyzer._validate_totals(model)
+        assert result.suspect is not None
+        assert result.suspect.name == "Soda"
+
+
+class TestBuildRetryHint:
+    """Unit tests for the retry hint builder."""
+
+    def test_hint_mentions_delta(self, analyzer):
+        result = _ReconciliationResult(
+            ok=False,
+            items_sum=Decimal("34.00"),
+            printed_subtotal=Decimal("22.00"),
+            delta=Decimal("12.00"),
+        )
+        hint = analyzer._build_retry_hint(result)
+        assert "34" in hint
+        assert "22" in hint
+        assert "12" in hint
+
+    def test_hint_mentions_suspect(self, analyzer):
+        # Classic misread: printed "$12" was extracted as unit_price=12, total_price=24.
+        # Corrected: printed $12 is the extended total, so unit_price=6 (12/2).
+        result = _ReconciliationResult(
+            ok=False,
+            items_sum=Decimal("34.00"),
+            printed_subtotal=Decimal("22.00"),
+            delta=Decimal("12.00"),
+            suspect=_SuspectItem(
+                name="Soda",
+                qty=2.0,
+                unit_price=Decimal("12.00"),  # the value printed on the receipt
+                total_price=Decimal("24.00"),  # what the model computed (wrong)
+            ),
+        )
+        hint = analyzer._build_retry_hint(result)
+        assert "Soda" in hint
+        # Corrected unit = 12 / 2 = 6.00
+        assert "6.00" in hint
+
+
+class TestAnalyzeImageWithGemini:
+    """
+    Integration-level tests for the two-pass retry flow.
+    Mocks genai.GenerativeModel so no real API calls are made.
+    """
+
+    IMAGE_BYTES = b"fake-image-data"
+
+    def _make_model_mock(self, responses: list):
+        """Return a mock that delivers *responses* in order on successive calls."""
+        mock_model = MagicMock()
+        mock_model.generate_content.side_effect = responses
+        return mock_model
+
+    @patch("image_analyzer.genai.GenerativeModel")
+    def test_happy_path_no_retry(self, mock_gm_cls, analyzer):
+        """When totals reconcile on the first pass, generate_content is called once."""
+        mock_gm_cls.return_value = self._make_model_mock(
+            [_gemini_response(_good_receipt())]
+        )
+        result = analyzer._analyze_image_with_gemini(self.IMAGE_BYTES)
+
+        mock_gm_cls.return_value.generate_content.assert_called_once()
+        assert isinstance(result, RegularReceipt)
+        assert result.merchant == "Good Cafe"
+
+    @patch("image_analyzer.genai.GenerativeModel")
+    def test_retry_on_mismatch_and_succeeds(self, mock_gm_cls, analyzer):
+        """Mismatch on first pass triggers retry; corrected response is used."""
+        mock_gm_cls.return_value = self._make_model_mock(
+            [
+                _gemini_response(_bad_receipt()),
+                _gemini_response(_corrected_receipt()),
+            ]
+        )
+        result = analyzer._analyze_image_with_gemini(self.IMAGE_BYTES)
+
+        assert mock_gm_cls.return_value.generate_content.call_count == 2
+        assert isinstance(result, RegularReceipt)
+        # After retry the soda item should have the corrected unit price
+        soda = next(i for i in result.line_items if i.name == "Soda")
+        assert soda.total_price == Decimal("12.00")
+        assert soda.price_per_item == Decimal("6.00")
+
+    @patch("image_analyzer.genai.GenerativeModel")
+    def test_unreconciled_after_retry_falls_back_to_first(self, mock_gm_cls, analyzer, caplog):
+        """When both passes fail to reconcile, the first response is returned (not raised)."""
+        mock_gm_cls.return_value = self._make_model_mock(
+            [
+                _gemini_response(_bad_receipt()),
+                _gemini_response(_bad_receipt()),
+            ]
+        )
+        with caplog.at_level(logging.ERROR, logger="image_analyzer"):
+            result = analyzer._analyze_image_with_gemini(self.IMAGE_BYTES)
+
+        assert mock_gm_cls.return_value.generate_content.call_count == 2
+        assert isinstance(result, RegularReceipt)
+        assert "Unreconciled after retry" in caplog.text
+
+    @patch("image_analyzer.RECEIPT_RETRY_ON_MISMATCH", False)
+    @patch("image_analyzer.genai.GenerativeModel")
+    def test_retry_disabled_no_second_call(self, mock_gm_cls, analyzer, caplog):
+        """When RECEIPT_RETRY_ON_MISMATCH is False, mismatches are not retried."""
+        mock_gm_cls.return_value = self._make_model_mock(
+            [_gemini_response(_bad_receipt())]
+        )
+        with caplog.at_level(logging.WARNING, logger="image_analyzer"):
+            result = analyzer._analyze_image_with_gemini(self.IMAGE_BYTES)
+
+        mock_gm_cls.return_value.generate_content.assert_called_once()
+        # No retry warning; mismatch was silently accepted
+        assert "retrying" not in caplog.text
+        assert isinstance(result, RegularReceipt)

--- a/backend/tests/test_image_analyzer_reconciliation.py
+++ b/backend/tests/test_image_analyzer_reconciliation.py
@@ -10,11 +10,10 @@ import json
 import logging
 from decimal import Decimal
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-import image_analyzer as ia
 from image_analyzer import (
     RECONCILIATION_TOLERANCE,
     ImageAnalyzer,

--- a/backend/tests/test_image_analyzer_reconciliation.py
+++ b/backend/tests/test_image_analyzer_reconciliation.py
@@ -138,6 +138,27 @@ class TestValidateTotals:
         assert result.suspect is not None
         assert result.suspect.name == "Soda"
 
+    def test_delta_is_non_negative_when_items_sum_below_subtotal(self, analyzer):
+        """
+        delta must be absolute (non-negative) even when items_sum < printed_subtotal.
+
+        Regression guard: returning `items_sum - printed_subtotal` without .copy_abs()
+        would yield -12.00 here, breaking any caller that expects a non-negative delta.
+        """
+        receipt = _good_receipt()
+        # Remove one item so items_sum (10) falls below the printed subtotal (22).
+        receipt["line_items"] = [
+            {"name": "Sandwich", "quantity": 1, "price_per_item": 10.00, "total_price": 10.00},
+        ]
+        model = RegularReceipt.model_validate(receipt)
+        result = analyzer._validate_totals(model)
+
+        assert result.ok is False
+        assert result.delta >= Decimal("0"), (
+            f"delta should be non-negative (absolute), got {result.delta}"
+        )
+        assert result.delta == Decimal("12.00")
+
 
 class TestBuildRetryHint:
     """Unit tests for the retry hint builder."""


### PR DESCRIPTION
…yzer

Teach the Gemini prompt that the printed subtotal is the source of truth for line-item totals, add explicit unit-vs-extended-total disambiguation rules and a worked example, and enforce a self-check invariant before emitting JSON.

Add server-side _validate_totals that detects when sum(line_item.total_price) diverges from the printed subtotal by more than $0.05, identifies the likely suspect line item, and triggers one targeted Gemini retry with arithmetic hints. Falls back to the first response if the retry also fails, logging an ERROR-level event for observability. Controlled by RECEIPT_RETRY_ON_MISMATCH flag for easy incident-response disabling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added receipt reconciliation to verify extracted line-item sums against printed subtotals, with a single automatic retry that attempts arithmetic correction when mismatches exceed a configurable tolerance; falls back to the original extraction if reconciliation still fails.

* **Tests**
  * Added tests for reconciliation logic, suspect-item detection, retry hint generation, and end-to-end two-pass extraction flows (including retry-disabled scenarios).

* **Documentation**
  * Documented new RECEIPT_RETRY_ON_MISMATCH toggle in example environment config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->