### PR TITLE
Remove hero tagline section from home page

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -157,20 +157,6 @@ const HomePage = () => {
           )}
         </m.section>
 
-        {/* ── Hero ── */}
-        <m.section {...fadeUp(0, shouldReduceMotion)}>
-          <div className="mb-4 flex justify-center">
-            <span className="rounded-full bg-accent px-3.5 py-1 text-xs font-medium tracking-wide text-accent-foreground">
-              <Trans>receipt splitting, simplified</Trans>
-            </span>
-          </div>
-          <p className="text-center text-sm leading-relaxed text-muted-foreground">
-            <Trans>
-              Scan a receipt, divide costs fairly, settle up in seconds.
-            </Trans>
-          </p>
-        </m.section>
-
         {/* ── Receipt history (signed-in only) ── */}
         <SignedIn>
           <m.section {...fadeUp(0.2, shouldReduceMotion)}>


### PR DESCRIPTION
## Summary
Removes the highlighted "Hero" block from the home page — the **receipt splitting, simplified** badge and the *Scan a receipt, divide costs fairly, settle up in seconds.* tagline.

## Changes
- Deleted the hero `<m.section>` from `frontend/src/pages/HomePage.tsx`. The uploader, receipt history, and "how it works" sections are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed the marketing hero content from the home page, creating a more direct flow from the upload area to the receipt history section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->