### PR TITLE
Fix prod blank page: eliminate duplicate @clerk/clerk-react runtime

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@clerk/clerk-react": "^5.61.3",
     "@clerk/localizations": "^4.12.0",
     "@clerk/react-router": "^2.4.15",
     "@fontsource-variable/fraunces": "^5.2.9",

--- a/frontend/src/components/Auth/AuthenticatedOnly.tsx
+++ b/frontend/src/components/Auth/AuthenticatedOnly.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from '@clerk/clerk-react';
+import { useAuth } from '@clerk/react-router';
 import { Loader2 } from 'lucide-react';
 import React from 'react';
 

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,29 +1,12 @@
 import { Trans } from '@lingui/react/macro';
-import { useQuery } from '@tanstack/react-query';
 import { Receipt, Server } from 'lucide-react';
 
-const API_URL =
-  import.meta.env.REACT_APP_API_URL || 'http://localhost:5000/api';
+import { useApiHealth } from '@/hooks/useApiHealth';
 
 const currentYear = new Date().getFullYear();
 
-const fetchApiHealth = async (): Promise<'healthy' | 'unhealthy'> => {
-  const response = await fetch(`${API_URL}/health`);
-  const data = await response.json();
-  return data.status === 'healthy' ? 'healthy' : 'unhealthy';
-};
-
 export default function Footer() {
-  const { data, isError } = useQuery({
-    queryKey: ['api-health'],
-    queryFn: fetchApiHealth,
-    retry: false,
-    refetchOnWindowFocus: false,
-  });
-
-  const apiStatus: 'checking' | 'healthy' | 'unhealthy' = isError
-    ? 'unhealthy'
-    : (data ?? 'checking');
+  const apiStatus = useApiHealth();
 
   return (
     <footer className="mt-auto border-t border-border bg-card/40 py-2">

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,7 +3,7 @@ import {
   SignedOut,
   SignInButton,
   UserButton,
-} from '@clerk/clerk-react';
+} from '@clerk/react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Receipt } from 'lucide-react';
 import { Link } from 'react-router-dom';

--- a/frontend/src/features/assignments/SignInToClaimDialog.tsx
+++ b/frontend/src/features/assignments/SignInToClaimDialog.tsx
@@ -1,4 +1,4 @@
-import { SignInButton } from '@clerk/clerk-react';
+import { SignInButton } from '@clerk/react-router';
 import { Trans } from '@lingui/react/macro';
 
 import { Button } from '@/components/ui/button';

--- a/frontend/src/features/assignments/assignments-list.tsx
+++ b/frontend/src/features/assignments/assignments-list.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from '@clerk/clerk-react';
+import { useAuth } from '@clerk/react-router';
 import { Trans, useLingui } from '@lingui/react/macro';
 import Decimal from 'decimal.js';
 import React, { useReducer, useState } from 'react';

--- a/frontend/src/features/assignments/components/AssignedList.tsx
+++ b/frontend/src/features/assignments/components/AssignedList.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from '@clerk/clerk-react';
+import { useAuth } from '@clerk/react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Trans } from '@lingui/react/macro';
 import Decimal from 'decimal.js';

--- a/frontend/src/features/auth/SignInPromptCard.tsx
+++ b/frontend/src/features/auth/SignInPromptCard.tsx
@@ -1,4 +1,4 @@
-import { SignInButton } from '@clerk/clerk-react';
+import { SignInButton } from '@clerk/react-router';
 import { Trans } from '@lingui/react/macro';
 import { LogIn } from 'lucide-react';
 

--- a/frontend/src/features/bill-split/components/BillBreakdownCollab.tsx
+++ b/frontend/src/features/bill-split/components/BillBreakdownCollab.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from '@clerk/clerk-react';
+import { useAuth } from '@clerk/react-router';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { useZero } from '@rocicorp/zero/react';
 import { mutators } from '@splitzy/shared-zero/mutators';

--- a/frontend/src/features/receipt-image/ReceiptImageViewer.tsx
+++ b/frontend/src/features/receipt-image/ReceiptImageViewer.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from '@clerk/clerk-react';
+import { useAuth } from '@clerk/react-router';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { animated, useSpring } from '@react-spring/web';
 import { Download, Image as ImageIcon, Settings, Undo } from 'lucide-react';

--- a/frontend/src/features/receipt-upload/hooks/useReceiptAnalysis.ts
+++ b/frontend/src/features/receipt-upload/hooks/useReceiptAnalysis.ts
@@ -1,4 +1,4 @@
-import { useAuth } from '@clerk/clerk-react';
+import { useAuth } from '@clerk/react-router';
 import { useMutation } from '@tanstack/react-query';
 
 import type { ReceiptAnalysisResult } from '@/features/receipt-upload/types';

--- a/frontend/src/hooks/useApiHealth.test.tsx
+++ b/frontend/src/hooks/useApiHealth.test.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { useApiHealth } from '@/hooks/useApiHealth';
+import { server } from '@/mocks/server';
+
+const API_URL =
+  import.meta.env.REACT_APP_API_URL || 'http://localhost:5000/api';
+
+const renderWithClient = <T,>(hook: () => T) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderHook(hook, {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+};
+
+describe('useApiHealth', () => {
+  it('reports checking until the backend answers, then healthy', async () => {
+    const { result } = renderWithClient(() => useApiHealth());
+
+    expect(result.current).toBe('checking');
+    await waitFor(() => expect(result.current).toBe('healthy'));
+  });
+
+  it('reports unhealthy when the backend reports a non-healthy status', async () => {
+    server.use(
+      http.get(`${API_URL}/health`, () =>
+        HttpResponse.json({ status: 'degraded' })
+      )
+    );
+
+    const { result } = renderWithClient(() => useApiHealth());
+
+    await waitFor(() => expect(result.current).toBe('unhealthy'));
+  });
+
+  it('reports unhealthy when the health endpoint fails', async () => {
+    server.use(
+      http.get(
+        `${API_URL}/health`,
+        () => new HttpResponse(null, { status: 500 })
+      )
+    );
+
+    const { result } = renderWithClient(() => useApiHealth());
+
+    await waitFor(() => expect(result.current).toBe('unhealthy'));
+  });
+
+  it('gives every consumer of the shared query key the same status', async () => {
+    const { result } = renderWithClient(() => ({
+      first: useApiHealth(),
+      second: useApiHealth(),
+    }));
+
+    await waitFor(() => expect(result.current.first).toBe('healthy'));
+    expect(result.current.second).toBe('healthy');
+  });
+});

--- a/frontend/src/hooks/useApiHealth.ts
+++ b/frontend/src/hooks/useApiHealth.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+
+const API_URL =
+  import.meta.env.REACT_APP_API_URL || 'http://localhost:5000/api';
+
+export type ApiHealthStatus = 'checking' | 'healthy' | 'unhealthy';
+
+const fetchApiHealth = async (): Promise<'healthy' | 'unhealthy'> => {
+  const response = await fetch(`${API_URL}/health`);
+  if (!response.ok) {
+    return 'unhealthy';
+  }
+  const data = await response.json();
+  return data.status === 'healthy' ? 'healthy' : 'unhealthy';
+};
+
+/**
+ * Polls the backend health endpoint. Every caller must go through this hook:
+ * React Query dedupes by key, so a second `['api-health']` query with a
+ * different return shape would hand its value to whichever consumer rendered
+ * first and misreport the API status.
+ */
+export function useApiHealth(): ApiHealthStatus {
+  const { data, isError } = useQuery({
+    queryKey: ['api-health'],
+    queryFn: fetchApiHealth,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  if (isError) {
+    return 'unhealthy';
+  }
+
+  return data ?? 'checking';
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,7 +3,6 @@ import { msg } from '@lingui/core/macro';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { useQuery } from '@rocicorp/zero/react';
 import { queries } from '@splitzy/shared-zero/queries';
-import { useQuery as useReactQuery } from '@tanstack/react-query';
 import { domAnimation, LazyMotion, m } from 'framer-motion';
 import { useSetAtom } from 'jotai';
 import { AlertCircle } from 'lucide-react';
@@ -21,12 +20,10 @@ import {
   imageDimsAtom,
 } from '@/features/image-prep/atoms/imagePrepStateAtoms';
 import { ReceiptUploader } from '@/features/receipt-upload/ReceiptUploader';
+import { useApiHealth } from '@/hooks/useApiHealth';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { fromZeroReceipt } from '@/lib/receiptTypes';
-
-const API_URL =
-  import.meta.env.REACT_APP_API_URL || 'http://localhost:5000/api';
 
 const ReceiptHistorySection = () => {
   const [user, details] = useQuery(queries.users.receipts.byAuthUserId({}));
@@ -95,21 +92,7 @@ const HomePage = () => {
 
   useDocumentTitle('Home');
 
-  const { data: apiHealthy, isError: apiHealthError } = useReactQuery({
-    queryKey: ['api-health'],
-    queryFn: async () => {
-      const response = await fetch(`${API_URL}/health`);
-      if (!response.ok) {
-        return false;
-      }
-      const data = await response.json();
-      return data.status === 'healthy';
-    },
-    retry: false,
-    refetchOnWindowFocus: false,
-  });
-
-  const apiUnhealthy = apiHealthError || apiHealthy === false;
+  const apiUnhealthy = useApiHealth() === 'unhealthy';
 
   const handleContinue = useCallback(
     (file: File) => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { SignedIn, SignedOut, SignInButton } from '@clerk/clerk-react';
+import { SignedIn, SignedOut, SignInButton } from '@clerk/react-router';
 import { msg } from '@lingui/core/macro';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { useQuery } from '@rocicorp/zero/react';

--- a/frontend/src/pages/ReceiptsPage.tsx
+++ b/frontend/src/pages/ReceiptsPage.tsx
@@ -1,4 +1,4 @@
-import { SignedIn, SignedOut } from '@clerk/clerk-react';
+import { SignedIn, SignedOut } from '@clerk/react-router';
 import { Trans } from '@lingui/react/macro';
 import { useQuery } from '@rocicorp/zero/react';
 import { queries } from '@splitzy/shared-zero/queries';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ importers:
 
   frontend:
     dependencies:
-      '@clerk/clerk-react':
-        specifier: ^5.61.3
-        version: 5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@clerk/localizations':
         specifier: ^4.12.0
         version: 4.12.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -473,14 +470,6 @@ packages:
   '@clerk/backend@2.33.5':
     resolution: {integrity: sha512-YOzUYJfb1d4w+0rKKm+LnnNpkJGQ+NI/g7qmF3mgaSN9X9huteuwCZyufdsI7z2DDkwy/yGRgb9eUWV96t7xLg==}
     engines: {node: '>=18.17.0'}
-
-  '@clerk/clerk-react@5.61.3':
-    resolution: {integrity: sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg==}
-    engines: {node: '>=18.17.0'}
-    deprecated: 'This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
-    peerDependencies:
-      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
   '@clerk/clerk-react@5.61.8':
     resolution: {integrity: sha512-n+k3q3xeyDkIPGTVA1J4Pd0+6MbS9Ia04qNlecOztTHwFfcirO5hy4TpOXrpGnO+GzYBuUMp7pYc3//ybMdEfg==}
@@ -6494,13 +6483,6 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-dom
-
-  '@clerk/clerk-react@5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@clerk/shared': 3.47.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      tslib: 2.8.1
 
   '@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production (https://splitzy-kappa.vercel.app/) renders a completely blank page. The server returns HTTP 200 and all bundles load, but React throws `AuthContext not found` on first render and unmounts the entire tree.

**Root cause:** two copies of `@clerk/clerk-react` were bundled — `5.61.3` (direct dependency in `frontend/package.json`) and `5.61.8` (nested under `@clerk/react-router@2.4.15`, bumped in PR #125). Each copy creates its own `AuthContext`. `LocalizedClerkProvider` (via `@clerk/react-router`) published auth state into the 5.61.8 context, while `Header` and ten other files importing from `@clerk/clerk-react` read the 5.61.3 context, found nothing, and threw. `Header` renders above the router with no error boundary, hence the fully blank page.

[Blank page rendered by the pre-fix bundle](https://cursor.com/agents/bc-0651616f-8e00-45de-8d8b-8609bf92ae35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_before_fix_blank_page_authcontext_not_found.png)

## Fix

**Commit 1 — structural dedupe.** `@clerk/react-router` re-exports the full `@clerk/clerk-react` surface (`export * from '@clerk/clerk-react'` at runtime, verified in dist). All eleven files importing from `@clerk/clerk-react` now import from `@clerk/react-router` instead, and the direct `@clerk/clerk-react` dependency is removed. This makes the duplication structurally impossible rather than relying on two independently-versioned packages agreeing. The lockfile now resolves a single `@clerk/clerk-react@5.61.8`, and the production bundle contains exactly one `AuthContext` (previously two).

**Commit 2 — `['api-health']` query key collision.** `HomePage` and `Footer` shared the `['api-health']` React Query key but returned different shapes (boolean vs string), so the footer showed "unhealthy" even when the API was fine. Both now use a shared `useApiHealth` hook returning `'checking' | 'healthy' | 'unhealthy'`, with unit tests.

## Verification

- Lockfile and `node_modules/.pnpm` contain a single `@clerk/clerk-react@5.61.8`; built bundle greps to one `5.61.x` version string and one `AuthContext` occurrence (vs two on `main`).
- `pnpm run type-check` passes; lint 0 errors; 161 frontend tests pass (4 new).
- Headless-browser smoke test against the built bundle with production public config: `main` reproduces the exact blank page + `AuthContext not found`; this branch renders fully with zero page errors.

[Splitzy home page rendering after the fix, footer showing API healthy](https://cursor.com/agents/bc-0651616f-8e00-45de-8d8b-8609bf92ae35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_after_fix_app_renders_api_healthy.png)

## Follow-ups not addressable from the repo

- Production uses a Clerk **development** key (`pk_test_…`, `fair-quail-47.clerk.accounts.dev`). Not the cause of this outage, but a production Clerk instance should be provisioned and `VITE_CLERK_PUBLISHABLE_KEY` updated in Vercel.
- CI has no render smoke test, which is why #125 shipped this silently. A test that mounts the app and asserts `#root` is non-empty would catch this class of failure.
- Pre-existing drift: `pnpm --filter frontend run build` regenerates `frontend/src/locales/*.po` with a large diff (catalogs reference `BillBreakdownView.tsx` for strings now in `PersonCard.tsx`/`PersonItemsDialog.tsx`). Reverted here to keep the diff minimal.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0651616f-8e00-45de-8d8b-8609bf92ae35?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0651616f-8e00-45de-8d8b-8609bf92ae35&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated authentication across sign-in, protected content, assignments, receipts, and bill-splitting experiences for continued compatibility.
  - Standardized backend availability monitoring across the home page and footer.
  - Health indicators now consistently show checking, healthy, or unavailable states, including when the service cannot be reached.

- **Tests**
  - Added coverage for health checks, service failures, degraded responses, loading states, and consistent status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->